### PR TITLE
feeder/webadmin editserver bugfix

### DIFF
--- a/feeder/modules/webadmin.js
+++ b/feeder/modules/webadmin.js
@@ -229,6 +229,10 @@ function updateServers(req) {
 
   _feeder.writeConfig();
 
+  if (!(_config.webapi.database)) {
+    return Q(result);
+  }
+  
   return utils.dbConnect(_config.webapi.database)
     .then(function(cli) {
       return Q()


### PR DESCRIPTION
After editing/removing server in admin panel, webadmin tries to connect database while _config.webapi.database is NOT defined. This pull request fixes it.
