### PR TITLE
feeder postMatchReportToXonstat fix

### DIFF
--- a/feeder/feeder.node.js
+++ b/feeder/feeder.node.js
@@ -986,7 +986,7 @@ function postMatchReportToXonstat(addr, game, report) {
       uri: _config.feeder.xonstatSubmissionUrl,
       timeout: 10000,
       method: "POST",
-      headers: { "X-D0-Blind-Id-Detached-Signature": "dummy" },
+      headers: { "X-D0-Blind-Id-Detached-Signature": "dummy", "Content-Type": "text/plain" },
       body: report
     },
     function(err, response, body) {


### PR DESCRIPTION
This code looks like correct: http://pastebin.com/XSeABFeT
But console.log(req.body) doesn't show submitted match results.

If feeder puts content-type in submition request header, console.log(req.body) shows match results.
