### PR TITLE
start_game_id fix

### DIFF
--- a/xonstat/views/game.py
+++ b/xonstat/views/game.py
@@ -250,7 +250,7 @@ def game_finder_data(request):
     recent_games = [RecentGame(row) for row in rgs_q.limit(20).all()]
     
     if len(recent_games) > 0:
-        query['start_game_id'] = recent_games[-1].game_id + 1
+        query['start_game_id'] = recent_games[-1].game_id - 1
 
     # build the list of links for the stripe across the top
     game_type_links = []


### PR DESCRIPTION
game_id is descending. so start_game_id must be lower than last game_id.
if using plus, instead of minus, link to last game appears in the next page

For example:
http://qlstats.net/games?server_id=919&type=overall&start_game_id=813507 (first)
http://qlstats.net/games?server_id=919&type=overall&start_game_id=804895 (link in next button from first page)

game_id = 804894 appears in both pages.
